### PR TITLE
refactor(auth_menu): 将菜单列表转换为树形结构

### DIFF
--- a/app/api/service/auth_menu.go
+++ b/app/api/service/auth_menu.go
@@ -88,9 +88,9 @@ func (a authMenuServiceImpl) List(auth *req.AuthReq) (res interface{}, e error) 
 	}
 	var respList []resp.MenuResp
 	response.Copy(&respList, menus)
-	//return util.ArrayUtil.ListToTree(
-	//	util.ConvertUtil.StructsToMaps(respList), "id", "pid", "children"), nil
-	return respList, nil
+	return util.ArrayUtil.ListToTree(
+		util.ConvertUtil.StructsToMaps(respList), "id", "pid", "children"), nil
+	// return respList, nil
 }
 
 func (a authMenuServiceImpl) Detail(id uint, auth *req.AuthReq) (res resp.MenuResp, e error) {


### PR DESCRIPTION
将菜单列表从平面结构转换为树形结构，以便更好地展示层级关系。移除旧的直接返回列表的代码，使用 `util.ArrayUtil.ListToTree` 方法进行转换。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Menu data is now displayed in a hierarchical tree structure instead of a flat list when viewing menus.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->