### PR TITLE
refactor: 重构前端API类型定义和请求逻辑

### DIFF
--- a/app/api/schemas/resp/auth.go
+++ b/app/api/schemas/resp/auth.go
@@ -46,22 +46,21 @@ type UserSelfResp struct {
 }
 
 type MenuResp struct {
-	ID         uint            `json:"id" structs:"id"`
-	Pid        uint            `json:"pid" structs:"pid"`
-	Name       string          `json:"name" structs:"name"`
-	Path       string          `json:"path" structs:"path"`
-	Component  string          `json:"component" structs:"component"`
-	Icon       string          `json:"icon" structs:"icon"`
-	MenuType   string          `json:"menu_type" structs:"menu_type"`
-	Cacheable  bool            `json:"cacheable" structs:"cacheable"`
-	RenderMenu bool            `json:"render_menu" structs:"render_menu"`
-	Permission string          `json:"permission" structs:"permission"`
-	Sort       uint16          `json:"sort" structs:"sort"`
-	Target     string          `json:"target" structs:"target"`
-	Badge      string          `json:"badge" structs:"badge"`
-	Button     []MenuButton    `json:"button" structs:"button"`
-	CreatedAt  carbon.DateTime `json:"created_at" structs:"created_at"`
-	UpdatedAt  carbon.DateTime `json:"updated_at" structs:"updated_at"`
+	ID         uint         `json:"id" structs:"id"`
+	Title      string       `json:"title" structs:"title"`
+	Pid        uint         `json:"pid" structs:"pid"`
+	Name       string       `json:"name" structs:"name"`
+	Path       string       `json:"path" structs:"path"`
+	Component  string       `json:"component" structs:"component"`
+	Icon       string       `json:"icon" structs:"icon"`
+	MenuType   string       `json:"menu_type" structs:"menu_type"`
+	Cacheable  bool         `json:"cacheable" structs:"cacheable"`
+	RenderMenu bool         `json:"render_menu" structs:"render_menu"`
+	Permission string       `json:"permission" structs:"permission"`
+	Sort       uint16       `json:"sort" structs:"sort"`
+	Target     string       `json:"target" structs:"target"`
+	Badge      string       `json:"badge" structs:"badge"`
+	Button     []MenuButton `json:"button" structs:"button"`
 }
 
 type MenuButton struct {

--- a/front-end/src/App.vue
+++ b/front-end/src/App.vue
@@ -44,17 +44,17 @@
 
   const { logout, profile } = useAccountStore();
 
-  // // 获取个人信息
-  // profile().then((response) => {
-  //   const { account } = response;
-  //   user.name = account.username;
-  //   // user.avatar = account.avatar;
-  // });
+  // 获取个人信息
+  profile().then((response) => {
+    const { user: account } = response;
+    user.name = account.username;
+    // user.avatar = account.avatar;
+  });
 
   const showSetting = ref(false);
   const router = useRouter();
 
-  // useMenuStore().getMenuList();
+  useMenuStore().getMenuList();
 
   const { navigation, useTabs, theme, contentClass } = storeToRefs(useSettingStore());
   const themeConfig = computed(() => themeList.find((item) => item.key === theme.value)?.config ?? {});

--- a/front-end/src/api/account.ts
+++ b/front-end/src/api/account.ts
@@ -1,8 +1,7 @@
 import { post, get } from '@/utils/request/http';
-import { Response } from '@/types';
 
-export const login = (data: Account.LoginForm) => post<Response<Account.LoginResult>>('/account/login', data);
+export const login = (data: Account.LoginForm) => post<Account.LoginResult>('/account/login', data);
 
 // 租户信息
-export const getTenant = () => get<Response<Base.SelectOption[]>>('/account/tenant');
+export const getTenant = () => get<Base.SelectOption[]>('/account/tenant');
 

--- a/front-end/src/main.ts
+++ b/front-end/src/main.ts
@@ -1,5 +1,6 @@
 import { createApp } from 'vue';
 import App from './App.vue';
+import Antd from 'ant-design-vue';
 import router from '@/router';
 import stepin from 'stepin/es';
 import pinia from '@/store';
@@ -12,7 +13,7 @@ import '@/theme/index.less';
 import { AuthPlugin, IconfontPlugin } from '@/plugins';
 
 const app = createApp(App);
-
+app.use(Antd)
 app.use(pinia);
 app.use(router);
 app.use(stepin, { router });

--- a/front-end/src/pages/login/LoginBox.vue
+++ b/front-end/src/pages/login/LoginBox.vue
@@ -10,10 +10,9 @@
         <a-form-item :required="true" name="tenantId">
           <a-select
             v-model:value="form.tenantId"
+            :getPopupContainer="triggerNode => {return triggerNode.parentNode || document.body;}"
             placeholder="请选择租户"
-            class="login-select"
           >
-            <a-select-option :value="0">请选择租户</a-select-option>
             <a-select-option v-for="item in tenantList" :key="item.value" :value="item.value" :disabled="item.disabled">{{ item.label }}</a-select-option>
           </a-select>
         </a-form-item>
@@ -54,16 +53,15 @@
   const loading = ref(false);
 
   const form = reactive<Account.LoginForm>({
-    username: undefined,
-    password: undefined,
-    tenantId: undefined,
+    username: 'admin',
+    password: 'admin888',
+    tenantId: 1,
   });
-
   const tenantList = ref<Base.SelectOption[]>([]);
 
   const fetchTenantList = async () => {
-    tenantList.value = await getTenant()
-    console.log(tenantList.value)
+   const { data } = await getTenant()
+    tenantList.value = data;
   }
 
   const emit = defineEmits<{

--- a/front-end/src/store/account.ts
+++ b/front-end/src/store/account.ts
@@ -1,20 +1,18 @@
 import { defineStore } from 'pinia';
 import http from '../utils/request/http';
-import { Response } from '@/types';
 import { useMenuStore } from './menu';
 import { useAuthStore } from '@/plugins';
 import { useLoadingStore } from './loading';
 import {login} from "@/api/account";
 
 export interface Profile {
-  account: Account;
+  user: Account;
   permissions: string[];
   role: string;
 }
 export interface Account {
   username: string;
   avatar: string;
-  gender: number;
 }
 
 export type TokenResult = {
@@ -50,7 +48,12 @@ export const useAccountStore = defineStore('account', {
         password: password,
       } as Account.LoginForm;
       const res = await login(data)
-      console.log(res)
+      if (res) {
+        this.logged = true;
+        http.setAuthorization(`${res.data.token}`, 7200 * 1000, 'Authorization');
+        await useMenuStore().getMenuList();
+        return res.data;
+      }
     },
     async logout() {
       return new Promise<boolean>((resolve) => {
@@ -64,12 +67,13 @@ export const useAccountStore = defineStore('account', {
       const { setAuthLoading } = useLoadingStore();
       setAuthLoading(true);
       return http
-        .request<Account, Response<Profile>>('/account', 'get')
+        .request('/user/self', 'get')
         .then((response) => {
-          if (response.code === 0) {
+          if (response) {
             const { setAuthorities } = useAuthStore();
-            const { account, permissions, role } = response.data;
-            this.account = account;
+            const { user, permissions, role } = response.data;
+            console.log(user, permissions, role)
+            this.account = user;
             this.permissions = permissions;
             this.role = role;
             setAuthorities(permissions);

--- a/front-end/src/store/menu.ts
+++ b/front-end/src/store/menu.ts
@@ -12,6 +12,8 @@ import { useLoadingStore } from '@/store';
 
 export interface MenuProps {
   id?: number;
+  pid?: number;
+  sort?: number;
   name: string;
   path: string;
   title?: string;
@@ -26,6 +28,7 @@ export interface MenuProps {
   children?: MenuProps[];
   cacheable?: boolean;
   view?: string;
+  button?: number[];
 }
 
 /**
@@ -120,13 +123,14 @@ export const useMenuStore = defineStore('menu', () => {
     const { setPageLoading } = useLoadingStore();
     setPageLoading(true);
     return http
-      .request<MenuProps[], Response<MenuProps[]>>('/menu', 'GET')
+      .request<MenuProps[], Response<MenuProps[]>>('/auth/menu/route', 'GET')
       .then((res) => {
         const { data } = res;
+        console.log(data)
         menuList.value = data;
         replaceRoutes(toRoutes(data), false);
         checkMenuPermission();
-        return data;
+        return res;
       })
       .finally(() => setPageLoading(false));
   }

--- a/front-end/src/types/api.d.ts
+++ b/front-end/src/types/api.d.ts
@@ -1,0 +1,9 @@
+declare namespace Api {
+  interface Response<T> {
+    msg: string;
+    code: number;
+    data: T;
+  }
+}
+
+

--- a/front-end/src/types/index.ts
+++ b/front-end/src/types/index.ts
@@ -1,9 +1,3 @@
-export interface Response<T> {
-  msg: string;
-  code: number;
-  data: T;
-}
-
-export function isResponse(obj: any): obj is Response<any> {
-  return typeof obj === 'object' && obj.msg !== undefined && obj.code !== undefined;
+export function isResponse(obj: any): obj is Api.Response<any> {
+    return typeof obj === 'object' && obj.msg !== undefined && obj.code !== undefined;
 }

--- a/front-end/src/utils/request/http.ts
+++ b/front-end/src/utils/request/http.ts
@@ -1,17 +1,16 @@
 import { AxiosRequestConfig, AxiosResponse } from 'axios';
 import createHttp from '@/utils/request/axiosHttp';
-import { isResponse } from '@/types';
 import NProgress from 'nprogress';
 import { notification } from 'ant-design-vue';
-
+import Cookie from 'js-cookie';
+import {isResponse} from "@/types";
 const http = createHttp({
   timeout: 10000,
   baseURL: 'api',
   withCredentials: true,
-  xsrfCookieName: 'Authorization',
-  xsrfHeaderName: 'Authorization',
     headers: {
       'Content-Type': 'application/json;charset=UTF-8',
+        'Authorization': `${Cookie.get('Authorization')}`,
     },
 });
 
@@ -33,7 +32,7 @@ http.interceptors.response.use(
     const { data } = rep;
     if (isResponse(data)) {
         if (data.code === 200) {
-            return Promise.resolve(data.data);
+            return Promise.resolve(data);
         } else if (data.code === 310) {
             notification.error({
                 message: data.msg,
@@ -85,21 +84,15 @@ export const get = <T = any>(
     url: string,
     params?: Record<string, unknown>,
     config?: AxiosRequestConfig
-): Promise<AxiosResponse<T>> => {
-    return http.request<T>(url, 'GET', params, config);
+): Promise<Api.Response<T>> => {
+    return http.request<T, Api.Response<T>>(url, 'GET', params, config);
 };
 
-// POST请求使用data负载
+// 泛型方式定义请求函数类型
 export const post = <T = any>(
     url: string,
     data?: unknown,
     config?: AxiosRequestConfig
-): Promise<AxiosResponse<T>> => {
-    return http.request<T>(url, 'post_json', data, {
-        ...config,
-        headers: {
-            'Content-Type': 'application/json', // 👈 关键配置
-            ...config?.headers,
-        }
-    });
+): Promise<Api.Response<T>> => {
+    return http.request<T, Api.Response<T>>(url, 'POST_JSON', data, config);
 };

--- a/public/sql/auth_menus.sql
+++ b/public/sql/auth_menus.sql
@@ -1,23 +1,3 @@
-INSERT INTO `auth_menus` (`created_at`,`updated_at`,`pid`,`name`,`path`,`redirect`,`componentPath`,`isDisabled`,`icon`,`menuType`,`title`,`requiresAuth`,`keepAlive`,`hide`,`sort`,`href`,`activeMenu`,`withoutTab`,`pinTab`) VALUES
-	 ('2025-05-11 16:18:50.855','2025-05-11 16:18:50.855',0,'workbench','/workbench','','/dashboard/workbench/index.vue',0,'icon-park-outline:alarm','page','工作台',1,0,0,0,NULL,NULL,0,1),
-	 ('2025-05-11 16:18:50.855','2025-05-13 22:43:36.204',0,'auth','/auth','','',0,'icon-park-outline:coordinate-system','dir','系统设置',1,0,0,99,'','',0,0),
-	 ('2025-05-11 16:18:50.855','2025-05-11 16:18:50.855',2,'auth_menu','/auth/menu','','/auth/menu/index.vue',0,'icon-park-outline:application-menu','page','系统菜单',1,0,0,1,'','',0,0),
-	 ('2025-05-11 16:18:50.855','2025-05-11 16:18:50.855',0,'org','/org','','',0,'icon-park-outline:broadcast-one','dir','组织管理',1,0,0,98,'','',1,0),
-	 ('2025-05-11 16:18:50.855','2025-05-11 16:18:50.855',4,'org_dept','/org/dept','','/demo/map/index.vue',0,'carbon:category','page','部门管理',1,0,0,0,'','',1,0),
-	 ('2025-05-12 23:44:01.344','2025-05-13 22:34:59.802',0,'workflow','/workflow','','',0,'icon-park-outline:cross-ring-two','dir','流程',1,0,0,0,'','',1,0),
-	 ('2025-05-12 23:51:55.863','2025-05-12 23:53:27.497',6,'dept','/dept','','',0,'carbon:branch','dir','部门',1,0,0,0,'','',1,0),
-	 ('2025-05-12 23:54:55.724','2025-05-12 23:54:55.724',7,'dept_index','/dept/index','','/workflow/dept/index.vue',0,'icon-park-outline:broadcast-one','page','部门管理',1,0,0,0,'','',1,0),
-	 ('2025-05-12 23:56:40.484','2025-05-12 23:56:40.484',6,'emp','/emp','','',0,'icon-park-outline:user-business','dir','员工',1,0,0,0,'','',1,0),
-	 ('2025-05-12 23:57:49.182','2025-05-12 23:57:49.182',9,'emp_index','/emp/index','','/workflow/emp/index.vue',0,'icon-park-outline:data-user','page','员工管理',1,0,0,0,'','',1,0),
-	 ('2025-05-12 23:58:40.783','2025-05-12 23:58:40.783',6,'template','/template','','',0,'carbon:prompt-template','dir','模板',1,0,0,0,'','',1,0),
-	 ('2025-05-12 23:59:40.802','2025-05-12 23:59:40.802',11,'template_index','/template/index','','/workflow/template/index.vue',0,'icon-park-outline:document-folder','page','流程模板',1,0,0,0,'','',1,0),
-	 ('2025-05-13 00:02:33.778','2025-05-17 17:08:21.619',6,'flowtype','/workflow/flowtype','','',0,'icon-park-outline:book-open','dir','流程类型',1,0,0,0,'','',1,0),
-	 ('2025-05-13 00:03:46.197','2025-05-17 17:10:26.457',13,'flowtype_index','/workflow/flowtype/index','','/workflow/flowtype/index.vue',0,'icon-park-outline:list-fail','page','类型配置',1,0,0,0,'','',1,0),
-	 ('2025-05-13 20:59:39.117','2025-05-13 22:45:04.111',6,'workflow_flow','/workflow/flow','','',0,'carbon:ibm-engineering-lifecycle-mgmt','dir','流程引擎',1,0,0,0,'','',1,0),
-	 ('2025-05-13 21:01:02.841','2025-05-13 22:46:48.647',15,'flow_index','/workflow/flow/index','','/workflow/flow/index.vue',0,'icon-park-outline:benz','page','设计',1,0,0,1,'','',1,0),
-	 ('2025-05-13 21:02:51.047','2025-05-13 22:46:36.252',15,'flow_create','/workflow/flow/create','','/workflow/flow/create.vue',0,'carbon:calendar-add','page','创建流程',1,0,1,0,'','',0,0),
-	 ('2025-05-13 21:04:09.311','2025-05-13 22:46:22.273',15,'flow_edit','/workflow/flow/:id/edit','','/workflow/flow/edit.vue',0,'icon-park-outline:badge','page','编辑流程',1,0,1,0,'','',0,0),
-	 ('2025-05-13 21:05:38.006','2025-05-13 22:46:06.779',15,'flow_initiation','/workflow/flow/:id/flow_initiation','','/workflow/flow/initiation.vue',0,'icon-park-outline:stopwatch-start','page','流程初始化',1,0,1,0,'','',0,0),
-	 ('2025-05-13 21:07:52.009','2025-05-13 22:45:51.791',15,'flow_design','/workflow/flow/:id/design','','/workflow/flow/design.vue',0,'icon-park-outline:pencil','page','设计流程图',1,0,1,0,'','',0,0),
-	 ('2025-05-13 21:09:51.870','2025-05-13 22:45:39.613',15,'flow_entry','/workflow/flow/:flow_id/entry/:entry_id','','/workflow/flow/entrydata.vue',0,'icon-park-outline:form-one','page','流程表单',1,0,1,0,'','',0,0),
-	 ('2025-05-13 21:13:49.715','2025-05-13 22:45:19.490',15,'flow_proc','/workflow/flow/:flow_id/proc/:entry_id','','/workflow/flow/proc.vue',0,'icon-park-outline:circles-seven','page','审核批复',1,0,1,0,'','',0,0);
+INSERT INTO `workflow`.`auth_menus` (`id`, `created_at`, `updated_at`, `pid`, `title`, `name`, `path`, `component`, `icon`, `menu_type`, `cacheable`, `render_menu`, `permission`, `sort`, `target`, `badge`) VALUES 
+(1, '2025-05-11 16:18:50.855', '2025-05-11 16:18:50.855', 0, '工作台', 'workplace', '/workplace', '@/pages/workplace', 'DashboardOutlined', 'menu', 0, 1, NULL, 0, '_self', 'new'),
+(2, '2025-05-11 16:18:50.855', '2025-05-11 16:18:50.855', 0, '表格', 'table', '/table', '@/pages/table', 'TableOutlined', 'menu', 1, 1, NULL, 1, '_self', NULL);


### PR DESCRIPTION
- 将`Response`类型定义移至`api.d.ts`并统一使用`Api.Response`类型
- 重构`http.ts`中的请求逻辑，简化泛型定义和请求处理
- 更新`account.ts`和`menu.ts`中的API调用以适配新的类型定义
- 修复`LoginBox.vue`中的租户选择器样式和默认值
- 更新`App.vue`中的用户信息获取逻辑