### PR TITLE
refactor: 更新认证相关配置以统一使用token

### DIFF
--- a/app/api/middleware/auth.go
+++ b/app/api/middleware/auth.go
@@ -133,7 +133,7 @@ func AuthCheck(db *gorm.DB, cr *cache.Redis) gin.HandlerFunc {
 }
 
 func getToken(c *gin.Context) string {
-	token := c.GetHeader("Authorization")
+	token := c.GetHeader("token")
 	if token == "" {
 		token = c.Query("token")
 	}

--- a/config.yaml
+++ b/config.yaml
@@ -7,8 +7,8 @@ database:
   driver: mysql
   host: 127.0.0.1
   port: 3306
-  username: root
-  password: Dazhouquxian2012.
+  username: workflow
+  password: 5MpFR8d6ZkJH5etF
   database: workflow
   auto_migrate: "true"
   params: "charset=utf8mb4&parseTime=True&loc=Local"

--- a/front-end/src/store/account.ts
+++ b/front-end/src/store/account.ts
@@ -50,7 +50,7 @@ export const useAccountStore = defineStore('account', {
       const res = await login(data)
       if (res) {
         this.logged = true;
-        http.setAuthorization(`${res.data.token}`, 7200 * 1000, 'Authorization');
+        http.setAuthorization(`${res.data.token}`, 7200 * 1000, 'token');
         await useMenuStore().getMenuList();
         return res.data;
       }

--- a/front-end/src/utils/request/http.ts
+++ b/front-end/src/utils/request/http.ts
@@ -8,9 +8,11 @@ const http = createHttp({
   timeout: 10000,
   baseURL: 'api',
   withCredentials: true,
+    xsrfCookieName: 'token',
+    xsrfHeaderName: 'token',
     headers: {
       'Content-Type': 'application/json;charset=UTF-8',
-        'Authorization': `${Cookie.get('Authorization')}`,
+        'token': `${Cookie.get('token')}`,
     },
 });
 


### PR DESCRIPTION
- 将数据库配置中的用户名和密码更新为更安全的凭据
- 修改认证中间件和前端请求库，统一使用`token`作为认证头字段
- 更新前端存储逻辑，确保token设置与认证头字段一致